### PR TITLE
Added Two-Minute Windows and Stacked Bars

### DIFF
--- a/data_analysis.py
+++ b/data_analysis.py
@@ -600,11 +600,11 @@ def generate_click_stream_plot(axes: plt.Axes, stimulus_data: pd.DataFrame):
     click_stream = stimulus_data.resample(WINDOW)[[MOUSE_EVENT, KEY_CODE]].count()
     time = convert_date_to_time(click_stream.index)
     minutes = int(WINDOW[:-1]) / 60
-    width = minutes - minutes / 10  # .20
-    axes.bar(time, click_stream[KEY_CODE].values, width=width, align="edge", label="Keyboard Events")
+    width = minutes
+    axes.bar(time, click_stream[KEY_CODE].values, width=width, align="edge", label="Keyboard Events", edgecolor="black")
     accumulator = click_stream[KEY_CODE].values
     for column in data:
-        axes.bar(time, data[column], width=width, align="edge", bottom=accumulator, label=column)
+        axes.bar(time, data[column], width=width, align="edge", bottom=accumulator, label=column, edgecolor="black")
         accumulator += data[column]
 
     # Clean up plot


### PR DESCRIPTION
Two-minutes windows work with the TimeDelta. There are some kinks when used with resampling, but it seems to work regardless. Also, the stacked bars work great! I added an edge color that obscures some of the smaller colors, but otherwise it looks good. Here's what that looks like:

![Click_Stream_Analysis](https://user-images.githubusercontent.com/11050412/97478653-9b9b5780-1927-11eb-8a32-b44c26b8223c.png)
